### PR TITLE
fix: extra whitespace in .plist files

### DIFF
--- a/Odin.docset/Contents/Info.plist
+++ b/Odin.docset/Contents/Info.plist
@@ -1,20 +1,18 @@
-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-            <key>CFBundleIdentifier</key>
-            <string>odin</string>
-            <key>CFBundleName</key>
-            <string>odin</string>
-            <key>DashDocSetFamily</key>
-            <string>odin</string>
-            <key>DocSetPlatformFamily</key>
-            <string>odin</string>
-            <key>isDashDocset</key>
-        	<true/>
-            <key>dashIndexFilePath</key>
-            <string>index.html</string>
-    </dict>
-    </plist>
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleIdentifier</key>
+        <string>odin</string>
+        <key>CFBundleName</key>
+        <string>odin</string>
+        <key>DashDocSetFamily</key>
+        <string>odin</string>
+        <key>DocSetPlatformFamily</key>
+        <string>odin</string>
+        <key>isDashDocset</key>
+        <true/>
+        <key>dashIndexFilePath</key>
+        <string>index.html</string>
+</dict>
+</plist>

--- a/Odin.docset/Contents/info.plist
+++ b/Odin.docset/Contents/info.plist
@@ -1,20 +1,18 @@
-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-    <plist version="1.0">
-    <dict>
-            <key>CFBundleIdentifier</key>
-            <string>odin</string>
-            <key>CFBundleName</key>
-            <string>odin</string>
-            <key>DashDocSetFamily</key>
-            <string>odin</string>
-            <key>DocSetPlatformFamily</key>
-            <string>odin</string>
-            <key>isDashDocset</key>
-        	<true/>
-            <key>dashIndexFilePath</key>
-            <string>index.html</string>
-    </dict>
-    </plist>
-
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>CFBundleIdentifier</key>
+        <string>odin</string>
+        <key>CFBundleName</key>
+        <string>odin</string>
+        <key>DashDocSetFamily</key>
+        <string>odin</string>
+        <key>DocSetPlatformFamily</key>
+        <string>odin</string>
+        <key>isDashDocset</key>
+        <true/>
+        <key>dashIndexFilePath</key>
+        <string>index.html</string>
+</dict>
+</plist>


### PR DESCRIPTION
Extra whitespaces prevent Zeal from parsing *.plist files