### PR TITLE
Fix download_pkgs_docs to include CSS styling

### DIFF
--- a/download_pkgs_docs.sh
+++ b/download_pkgs_docs.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
-wget -mpEk "https://pkg.odin-lang.org/"
+
 mkdir -p Odin.docset/Contents/Resources/Documents
-cp -R pkg.odin-lang.org/* Odin.docset/Contents/Resources/Documents/
+wget                                                          \
+  --mirror                                                    \
+  --page-requisites                                           \
+  --adjust-extension                                          \
+  --convert-links                                             \
+  --no-host-directories                                       \
+  --directory-prefix=Odin.docset/Contents/Resources/Documents \
+  "https://pkg.odin-lang.org"                                 \
+  "https://odin-lang.org/scss/custom.min.css"                 \
+  "https://odin-lang.org/css/style.css"                       \
+  "https://odin-lang.org/logo.svg"


### PR DESCRIPTION
- Downloads all css files
- Download Odin logo
- Remove the use of `cp`, replacing it with `--directory-prefix`

This PR is a duplicate (kinda) of https://github.com/drmargarido/odin-docset/pull/3 and https://github.com/drmargarido/odin-docset/pull/2, removing the need for a new tool while simplifying the script.

Code examples in the documentation will not be highlighted.
That would need javascript to be enabled and pulling both those resources : 
1. https://odin-lang.org/lib/highlight/styles/github-dark.min.css
2. https://odin-lang.org/lib/highlight/highlight.min.js

IMHO, example code can still easily be read without highlighting. 